### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,22 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Enable documentation builds on readthedocs, see https://fsc-hdf5-io.readthedocs.io/en/add_rtd_config

@mskoenz @donjan if you have an account on readthedocs I can add you as maintainers.

Note: A colon is not allowed (i.e., will be stripped) in the project name on RTD. I switched to using a dash (`fsc-hdf5-io`) instead, but this could be fixed with a custom domain.