### PR TITLE
Strip description of newlines to make setuptools happy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PKGNAME = 'hdf5_io'
 PKGNAME_QUALIFIED = 'fsc.' + PKGNAME
 
 with open('doc/description.txt', 'r') as f:
-    DESCRIPTION = f.read()
+    DESCRIPTION = f.read().strip()
 try:
     with open('doc/README', 'r') as f:
         README = f.read()


### PR DESCRIPTION
Setuptools emits a warning (and temporarily broke) when the
description contains a newline. For this reason, we strip the
unnecessary final newline from the description.