### PR TITLE
Fix compatibility with newer h5py version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,25 @@
 repos:
-- repo: git://github.com/pre-commit/mirrors-yapf
-  rev: v0.28.0
-  hooks:
-  - id: yapf
-    language: system
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
 
-- repo: git://github.com/guykisel/prospector-mirror
-  rev: 7ff847e779347033ebbd9e3b88279e7f3a998b45
-  hooks:
-  - id: prospector
-    language: system
-    exclude: '^(doc/)'
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.3
+    hooks:
+    - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 21.9b0
+    hooks:
+      - id: black
+
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        exclude: '^(doc/)'

--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=too-few-public-methods,too-many-public-methods,bad-continuation,wrong-import-position,line-too-long,locally-disabled,wildcard-import,locally-enabled,too-many-instance-attributes,cyclic-import
+disable=too-few-public-methods,too-many-public-methods,bad-continuation,wrong-import-position,line-too-long,locally-disabled,wildcard-import,locally-enabled,too-many-instance-attributes,cyclic-import,use-dict-literal
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,4 +1,0 @@
-[style]
-based_on_style = pep8
-coalesce_brackets = true
-dedent_closing_brackets = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
 env:
@@ -9,7 +8,7 @@ env:
   - TEST_TYPE="test_sympy"
 matrix:
   include:
-    - python: 3.6
+    - python: 3.7
       env: TEST_TYPE="compliance"
 install:
   - pip install .

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Z2Pack documentation build configuration file, created by
 # sphinx-quickstart on Fri Oct 10 02:14:52 2014.
@@ -22,20 +21,23 @@ import fsc.hdf5_io
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode',
-    'sphinx.ext.intersphinx', 'IPython.sphinxext.ipython_console_highlighting',
-    'IPython.sphinxext.ipython_directive'
+    "sphinx.ext.autodoc",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "IPython.sphinxext.ipython_directive",
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'h5py': ('http://docs.h5py.org/en/latest', None)
+    "python": ("https://docs.python.org/3", None),
+    "h5py": ("http://docs.h5py.org/en/latest", None),
 }
 
 rst_prolog = """
@@ -44,28 +46,28 @@ rst_prolog = """
 """
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-#~ master_doc = 'index'
-master_doc = 'index'
+# ~ master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'pyhdf5io'
-copyright = u'2017, C. Frescolino'
+project = "pyhdf5io"
+copyright = "2017, C. Frescolino"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = '.'.join(fsc.hdf5_io.__version__.split('.')[:2])
+version = ".".join(fsc.hdf5_io.__version__.split(".")[:2])
 # The full version, including alpha/beta/rc tags.
 release = fsc.hdf5_io.__version__
 
@@ -78,65 +80,65 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['doc.rst']
-#~ exclude_patterns = ['index.rst']
+exclude_patterns = ["doc.rst"]
+# ~ exclude_patterns = ['index.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
 show_authors = True
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#~ html_theme = 'basicstrap'
-html_theme = 'sphinx_rtd_theme'
+# ~ html_theme = 'basicstrap'
+html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#~ html_theme_options = {
-#~ 'inner_theme': True,
-#~ 'inner_theme_name': 'bootswatch-darkly',
-#~ 'nav_fixed_top': False
-#~ }
+# ~ html_theme_options = {
+# ~ 'inner_theme': True,
+# ~ 'inner_theme_name': 'bootswatch-darkly',
+# ~ 'nav_fixed_top': False
+# ~ }
 
 # Add any paths that contain custom themes here, relative to this directory.
-#~ html_theme_path = ["."]
+# ~ html_theme_path = ["."]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -150,67 +152,67 @@ html_favicon = "../../../../media/logo/frescolino_favicon.ico"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#~ html_show_copyright = False
+# ~ html_show_copyright = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-html_use_opensearch = 'http://frescolinogroup.github.io/frescolino/hdf5_io/' + version
+html_use_opensearch = "http://frescolinogroup.github.io/frescolino/hdf5_io/" + version
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
-html_search_language = 'en'
+html_search_language = "en"
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'fsc_hdf5_io_doc'
+htmlhelp_basename = "fsc_hdf5_io_doc"

--- a/fsc/hdf5_io/__init__.py
+++ b/fsc/hdf5_io/__init__.py
@@ -2,13 +2,19 @@
 This module contains functions to save and load objects, using the HDF5 format.
 """
 
-from ._version import __version__
-
-from ._save_load import *
 from ._base_classes import *
-from ._subscribe import *
+from ._save_load import *
+
 # Needs to be loaded on import to define the special type serialization.
 from ._simple_mapping import *
 from ._special_types import *
+from ._subscribe import *
+from ._version import __version__
 
-__all__ = _save_load.__all__ + _base_classes.__all__ + _subscribe.__all__ + _simple_mapping.__all__  # pylint: disable=undefined-variable
+# pylint: disable=undefined-variable
+__all__ = (
+    _save_load.__all__
+    + _base_classes.__all__
+    + _subscribe.__all__
+    + _simple_mapping.__all__
+)

--- a/fsc/hdf5_io/_base_classes.py
+++ b/fsc/hdf5_io/_base_classes.py
@@ -13,6 +13,7 @@ class Deserializable(abc.ABC):
     """
     Base class for data which can be deserialized from the HDF5 format.
     """
+
     @classmethod
     @abc.abstractmethod
     def from_hdf5(cls, hdf5_handle):
@@ -29,7 +30,7 @@ class Deserializable(abc.ABC):
         :param hdf5_file: Path of the file.
         :type hdf5_file: str
         """
-        with h5py.File(hdf5_file, 'r') as f:
+        with h5py.File(hdf5_file, "r") as f:
             return cls.from_hdf5(f, *args, **kwargs)
 
 
@@ -37,6 +38,7 @@ class Serializable(abc.ABC):
     """
     Base class for data which can be serialized to the HDF5 format.
     """
+
     @abc.abstractmethod
     def to_hdf5(self, hdf5_handle):
         """
@@ -51,7 +53,8 @@ class Serializable(abc.ABC):
         :param hdf5_file: Path of the file.
         :type hdf5_file: str
         """
-        from ._save_load import to_hdf5_file
+        from ._save_load import to_hdf5_file  # pylint: disable=import-outside-toplevel
+
         to_hdf5_file(self, hdf5_file)
 
 

--- a/fsc/hdf5_io/_save_load.py
+++ b/fsc/hdf5_io/_save_load.py
@@ -2,14 +2,15 @@
 Defines free functions to serialize / deserialize bands-inspect objects to HDF5.
 """
 
-from functools import singledispatch, lru_cache
+from functools import lru_cache, singledispatch
 
 import h5py
+
 from fsc.export import export
 
 from ._subscribe import SERIALIZE_MAPPING, TYPE_TAG_KEY
 
-__all__ = ['save', 'load']
+__all__ = ["save", "load"]
 
 
 @lru_cache(maxsize=None)
@@ -18,7 +19,8 @@ def _get_entrypoint_mapping(group):
     Helper function to get the entry point mapping corresponding to a
     given group name
     """
-    import pkg_resources
+    import pkg_resources  # pylint: disable=import-outside-toplevel
+
     return {ep.name: ep for ep in pkg_resources.iter_entry_points(group=group)}
 
 
@@ -40,11 +42,9 @@ def _try_loading_parts(*, identifier, entry_point_mapping):
 
     :returns: The name of the entry point that was loaded (if any), or False.
     """
-    split_identifier = identifier.split('.')
+    split_identifier = identifier.split(".")
     for partial_identifier_length in range(len(split_identifier), 0, -1):
-        partial_identifier = '.'.join(
-            split_identifier[:partial_identifier_length]
-        )
+        partial_identifier = ".".join(split_identifier[:partial_identifier_length])
         if partial_identifier in entry_point_mapping:
             entry_point_mapping[partial_identifier].load()
             return partial_identifier
@@ -60,30 +60,27 @@ def from_hdf5(hdf5_handle):
     :type hdf5_handle: :py:class:`h5py.File<File>` or :py:class:`h5py.Group<Group>`.
     """
     try:
-        type_tag = hdf5_handle[TYPE_TAG_KEY][()].decode('utf-8')
+        type_tag = hdf5_handle[TYPE_TAG_KEY][()].decode("utf-8")
     except KeyError as err:
         raise ValueError(
-            "HDF5 object '{}' cannot be de-serialized: No type information given."
-            .format(hdf5_handle.name)
+            f"HDF5 object '{hdf5_handle.name}' cannot be de-serialized: No type information given."
         ) from err
     try:
         obj_class = SERIALIZE_MAPPING[type_tag]
     except KeyError as err:
         partial_tag = _try_loading_parts(
             identifier=type_tag,
-            entry_point_mapping=_get_entrypoint_mapping('fsc.hdf5_io.load')
+            entry_point_mapping=_get_entrypoint_mapping("fsc.hdf5_io.load"),
         )
         if not partial_tag:
             raise KeyError(
-                "Unknown {} '{}'. The module defining this class has not been imported, and no matching entry point was found."
-                .format(TYPE_TAG_KEY, type_tag)
+                f"Unknown {TYPE_TAG_KEY} '{type_tag}'. The module defining this class has not been imported, and no matching entry point was found."
             ) from err
         try:
             obj_class = SERIALIZE_MAPPING[type_tag]
         except KeyError as err2:
             raise KeyError(
-                "Unknown {} '{}'. The module defining this class has not been imported, even after loading entry point {}."
-                .format(TYPE_TAG_KEY, type_tag, partial_tag)
+                f"Unknown {TYPE_TAG_KEY} '{type_tag}'. The module defining this class has not been imported, even after loading entry point {partial_tag}."
             ) from err2
     return obj_class.from_hdf5(hdf5_handle)
 
@@ -98,29 +95,26 @@ def to_hdf5(obj, hdf5_handle):
     :param hdf5_handle: HDF5 location where the serialized object gets stored.
     :type hdf5_handle: :py:class:`h5py.File<File>` or :py:class:`h5py.Group<Group>`.
     """
-    if hasattr(obj, 'to_hdf5'):
+    if hasattr(obj, "to_hdf5"):
         obj.to_hdf5(hdf5_handle)
     else:
         try:
             to_hdf5_singledispatch(obj, hdf5_handle)
-        except SerializerNotFound:
+        except SerializerNotFound as exc:
             objtype = type(obj)
             objmodule = objtype.__module__
             if objmodule is None:
                 fullname = objtype.__qualname__
             else:
-                fullname = objmodule + '.' + objtype.__qualname__
+                fullname = objmodule + "." + objtype.__qualname__
 
             if not _try_loading_parts(
                 identifier=fullname,
-                entry_point_mapping=_get_entrypoint_mapping(
-                    'fsc.hdf5_io.save'
-                )
+                entry_point_mapping=_get_entrypoint_mapping("fsc.hdf5_io.save"),
             ):
                 raise TypeError(
-                    "Cannot serialize object of type '{}', and no corresponding entry point found."
-                    .format(fullname)
-                )
+                    f"Cannot serialize object of type '{fullname}', and no corresponding entry point found."
+                ) from exc
             to_hdf5_singledispatch(obj, hdf5_handle)
 
 
@@ -129,6 +123,8 @@ class SerializerNotFound(TypeError):
     Error to raise when the singledispatch for serializing an object to
     HDF5 format fails to find a matching function.
     """
+
+
 @export
 @singledispatch
 def to_hdf5_singledispatch(obj, hdf5_handle):
@@ -140,9 +136,7 @@ def to_hdf5_singledispatch(obj, hdf5_handle):
     :param hdf5_handle: HDF5 location where the serialized object gets stored.
     :type hdf5_handle: :py:class:`h5py.File<File>` or :py:class:`h5py.Group<Group>`.
     """
-    raise SerializerNotFound(
-        "Cannot serialize object '{}' of type '{}'".format(obj, type(obj))
-    )
+    raise SerializerNotFound(f"Cannot serialize object '{obj}' of type '{type(obj)}'")
 
 
 @export
@@ -153,7 +147,7 @@ def from_hdf5_file(hdf5_file):
     :param hdf5_file: Path of the file.
     :type hdf5_file: str
     """
-    with h5py.File(hdf5_file, 'r') as f:
+    with h5py.File(hdf5_file, "r") as f:
         return from_hdf5(f)
 
 
@@ -171,7 +165,7 @@ def to_hdf5_file(obj, hdf5_file):
     :param hdf5_file: Path of the file.
     :type hdf5_file: str
     """
-    with h5py.File(hdf5_file, 'w') as f:
+    with h5py.File(hdf5_file, "w") as f:
         to_hdf5(obj, f)
 
 

--- a/fsc/hdf5_io/_simple_mapping.py
+++ b/fsc/hdf5_io/_simple_mapping.py
@@ -38,7 +38,7 @@ class SimpleHDF5Mapping(HDF5Enabled):
             hdf5_obj = hdf5_handle[key]
             try:
                 kwargs[key] = hdf5_obj[()]
-            except AttributeError:
+            except (AttributeError, TypeError):
                 kwargs[key] = _global_from_hdf5(hdf5_obj)
         return cls(**kwargs)
 

--- a/fsc/hdf5_io/_simple_mapping.py
+++ b/fsc/hdf5_io/_simple_mapping.py
@@ -7,7 +7,8 @@ import contextlib
 from fsc.export import export
 
 from ._base_classes import HDF5Enabled
-from ._save_load import to_hdf5 as _global_to_hdf5, from_hdf5 as _global_from_hdf5
+from ._save_load import from_hdf5 as _global_from_hdf5
+from ._save_load import to_hdf5 as _global_to_hdf5
 
 
 @export
@@ -23,6 +24,7 @@ class SimpleHDF5Mapping(HDF5Enabled):
     define a list ``HDF5_OPTIONAL``. The same logic as for the ``HDF5_ATTRIBUTES``
     applies, but no error is raised if an attribute does not exist.
     """
+
     HDF5_ATTRIBUTES = ()
     HDF5_OPTIONAL = ()
 
@@ -44,8 +46,7 @@ class SimpleHDF5Mapping(HDF5Enabled):
 
     def to_hdf5(self, hdf5_handle):
         self._check_hdf5_attributes_lists()
-        to_serialize = [(key, getattr(self, key))
-                        for key in self.HDF5_ATTRIBUTES]
+        to_serialize = [(key, getattr(self, key)) for key in self.HDF5_ATTRIBUTES]
         for key in self.HDF5_OPTIONAL:
             with contextlib.suppress(AttributeError):
                 to_serialize.append((key, getattr(self, key)))
@@ -65,19 +66,18 @@ class SimpleHDF5Mapping(HDF5Enabled):
         for key in cls.HDF5_ATTRIBUTES:
             if not isinstance(key, str):
                 raise ValueError(
-                    "The element '{key}' in {cls}.HDF5_ATTRIBUTES must be a string."
-                    .format(key=key, cls=cls)
+                    f"The element '{key}' in {cls}.HDF5_ATTRIBUTES must be a string."
                 )
         for key in cls.HDF5_OPTIONAL:
             if not isinstance(key, str):
                 raise ValueError(
-                    "The element '{key}' in {cls}.HDF5_OPTIONAL must be a string."
-                    .format(key=key, cls=cls)
+                    f"The element '{key}' in {cls}.HDF5_OPTIONAL must be a string."
                 )
 
         overlapping_keys = set(cls.HDF5_ATTRIBUTES) & set(cls.HDF5_OPTIONAL)
         if overlapping_keys:
             raise ValueError(
-                "The keys {overlapping_keys} are present in both {cls}.HDF5_ATTRIBUTES and {cls}.HDF5_OPTIONAL"
-                .format(overlapping_keys=overlapping_keys, cls=cls)
+                "The keys {overlapping_keys} are present in both {cls}.HDF5_ATTRIBUTES and {cls}.HDF5_OPTIONAL".format(
+                    overlapping_keys=overlapping_keys, cls=cls
+                )
             )

--- a/fsc/hdf5_io/_subscribe.py
+++ b/fsc/hdf5_io/_subscribe.py
@@ -7,7 +7,7 @@ from decorator import decorator
 from fsc.export import export
 
 SERIALIZE_MAPPING = {}
-TYPE_TAG_KEY = 'type_tag'
+TYPE_TAG_KEY = "type_tag"
 
 
 @export
@@ -24,17 +24,17 @@ def subscribe_hdf5(type_tag, extra_tags=(), check_on_load=True):
     :param check_on_load: Flag that determines whether the 'type_tag' is checked when de-serializing the object.
     :type check_on_load: bool
     """
+
     def inner(cls):
         all_type_tags = [type_tag] + list(extra_tags)
         for tag in all_type_tags:
             if tag in SERIALIZE_MAPPING:
                 raise ValueError(
-                    "The given type_tag '{}' exists already in the SERIALIZE_MAPPING"
-                    .format(tag)
+                    f"The given type_tag '{tag}' exists already in the SERIALIZE_MAPPING"
                 )
             SERIALIZE_MAPPING[tag] = cls
 
-        if hasattr(cls, 'to_hdf5'):
+        if hasattr(cls, "to_hdf5"):
 
             @decorator
             def set_type_tag(to_hdf5_func, self, hdf5_handle, *args, **kwargs):
@@ -44,21 +44,26 @@ def subscribe_hdf5(type_tag, extra_tags=(), check_on_load=True):
                     assert isinstance(self, cls)
                 return to_hdf5_func(self, hdf5_handle, *args, **kwargs)
 
-            cls.to_hdf5 = set_type_tag(cls.to_hdf5)  # pylint: disable=no-value-for-parameter
+            cls.to_hdf5 = set_type_tag(  # pylint: disable=no-value-for-parameter
+                cls.to_hdf5
+            )
 
         if check_on_load:
 
             @decorator
-            def check_type_tag(
-                from_hdf5_func, curr_cls, hdf5_handle, *args, **kwargs
-            ):
+            def check_type_tag(from_hdf5_func, curr_cls, hdf5_handle, *args, **kwargs):
                 # check only the top-level class.
                 if curr_cls == cls:
-                    assert hdf5_handle[TYPE_TAG_KEY][(
-                    )].decode('utf-8') in all_type_tags
+                    assert (
+                        hdf5_handle[TYPE_TAG_KEY][()].decode("utf-8") in all_type_tags
+                    )
                 return from_hdf5_func(curr_cls, hdf5_handle, *args, **kwargs)
 
-            cls.from_hdf5 = classmethod(check_type_tag(cls.from_hdf5.__func__))  # pylint: disable=no-value-for-parameter
+            cls.from_hdf5 = classmethod(
+                check_type_tag(  # pylint: disable=no-value-for-parameter
+                    cls.from_hdf5.__func__
+                )
+            )
         else:
             cls.from_hdf5 = classmethod(cls.from_hdf5.__func__)
         return cls

--- a/fsc/hdf5_io/_sympy_load.py
+++ b/fsc/hdf5_io/_sympy_load.py
@@ -2,14 +2,16 @@
 Module defining the deserialization method for sympy objects.
 """
 
+from ._special_types import Deserializable, _SpecialTypeTags
 from ._subscribe import subscribe_hdf5
-from ._special_types import _SpecialTypeTags, Deserializable
 
 
 @subscribe_hdf5(_SpecialTypeTags.SYMPY)
 class _SympyDeserializer(Deserializable):
     """Helper class to de-serialize sympy objects."""
+
     @classmethod
     def from_hdf5(cls, hdf5_handle):
-        import sympy
-        return sympy.sympify(hdf5_handle['value'][()].decode('utf-8'))
+        import sympy  # pylint: disable=import-outside-toplevel
+
+        return sympy.sympify(hdf5_handle["value"][()].decode("utf-8"))

--- a/fsc/hdf5_io/_sympy_save.py
+++ b/fsc/hdf5_io/_sympy_save.py
@@ -5,7 +5,10 @@ Module defining the serialization method for sympy objects.
 import sympy
 
 from ._special_types import (
-    _SpecialTypeTags, to_hdf5_singledispatch, _value_serializer, add_type_tag
+    _SpecialTypeTags,
+    _value_serializer,
+    add_type_tag,
+    to_hdf5_singledispatch,
 )
 
 

--- a/fsc/hdf5_io/_version.py
+++ b/fsc/hdf5_io/_version.py
@@ -4,5 +4,7 @@ Defines the module's version, read from the version.txt file.
 
 import pathlib
 
-with open(pathlib.Path(__file__).resolve().parent / 'version.txt', 'r') as f:
+with open(
+    pathlib.Path(__file__).resolve().parent / "version.txt", encoding="utf-8"
+) as f:
     __version__ = f.read().strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -6,50 +6,57 @@ import sys
 
 from setuptools import setup
 
-PKGNAME = 'hdf5_io'
-PKGNAME_QUALIFIED = 'fsc.' + PKGNAME
+PKGNAME = "hdf5_io"
+PKGNAME_QUALIFIED = "fsc." + PKGNAME
 
-with open('doc/description.txt', 'r') as f:
+with open("doc/description.txt") as f:
     DESCRIPTION = f.read().strip()
 try:
-    with open('doc/README', 'r') as f:
+    with open("doc/README") as f:
         README = f.read()
-except IOError:
+except OSError:
     README = DESCRIPTION
 
-with open('version.txt', 'r') as f:
+with open("version.txt") as f:
     VERSION = f.read().strip()
 
-if sys.version_info < (3, 6):
-    raise ValueError('only Python 3.6 and higher are supported')
+if sys.version_info < (3, 7):
+    raise ValueError("only Python 3.7 and higher are supported")
 
 setup(
     name=PKGNAME_QUALIFIED,
     version=VERSION,
     packages=[PKGNAME_QUALIFIED],
-    url='http://frescolinogroup.github.io/frescolino/pyhdf5io/' +
-    '.'.join(VERSION.split('.')[:2]),
+    url="http://frescolinogroup.github.io/frescolino/pyhdf5io/"
+    + ".".join(VERSION.split(".")[:2]),
     include_package_data=True,
-    author='C. Frescolino',
-    author_email='frescolino@lists.phys.ethz.ch',
+    author="C. Frescolino",
+    author_email="frescolino@lists.phys.ethz.ch",
     description=DESCRIPTION,
-    install_requires=['numpy>=1.17.5', 'decorator', 'h5py~=3.0', 'fsc.export'],
-    python_requires=">=3.6",
+    install_requires=["numpy>=1.17.5", "decorator", "h5py~=3.0", "fsc.export"],
+    python_requires=">=3.7",
     extras_require={
-        'dev': [
-            'pytest', 'pytest-cov', 'yapf==0.28.0', 'prospector==1.1.7',
-            'pre-commit', 'pylint==2.3.1', 'sphinx', 'sphinx-rtd-theme',
-            'ipython>=6.2', 'matplotlib', 'sympy'
+        "dev": [
+            "pytest",
+            "pytest-cov",
+            "pre-commit==2.15.0",
+            "pylint==2.11.1",
+            "sphinx",
+            "sphinx-rtd-theme",
+            "ipython>=6.2",
+            "matplotlib",
+            "sympy",
         ]
     },
     entry_points={
         "fsc.hdf5_io.load": ["sympy.object = fsc.hdf5_io._sympy_load"],
-        "fsc.hdf5_io.save": ["sympy = fsc.hdf5_io._sympy_save"]
+        "fsc.hdf5_io.save": ["sympy = fsc.hdf5_io._sympy_save"],
     },
     long_description=README,
     classifiers=[
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3', 'Topic :: Utilities'
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Topic :: Utilities",
     ],
-    license='Apache',
+    license="Apache",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 Configuration file for pytest tests.
 """
 
+# pylint: disable=protected-access
+
 import pathlib
 
 import pytest
@@ -10,7 +12,9 @@ import pytest
 @pytest.fixture
 def test_name(request):
     """Returns a unique name for each test instance."""
-    return request.module.__name__ + '/' + request._parent_request._pyfuncitem.name  # pylint: disable=protected-access
+    return (
+        request.module.__name__ + "/" + request._parent_request._pyfuncitem.name
+    )  # pylint: disable=protected-access
 
 
 @pytest.fixture
@@ -18,4 +22,4 @@ def sample_dir():
     """
     Returns the pathlib.Path of the samples directory.
     """
-    return pathlib.Path(__file__).resolve().parent / 'samples'
+    return pathlib.Path(__file__).resolve().parent / "samples"

--- a/tests/simple_class.py
+++ b/tests/simple_class.py
@@ -2,25 +2,24 @@
 Defines a simple serializable class.
 """
 
-from fsc.hdf5_io import subscribe_hdf5, HDF5Enabled, SimpleHDF5Mapping
+from fsc.hdf5_io import HDF5Enabled, SimpleHDF5Mapping, subscribe_hdf5
 
 
-@subscribe_hdf5(
-    'test.simple_class', extra_tags=('test.simple_class_old_tag', )
-)
+@subscribe_hdf5("test.simple_class", extra_tags=("test.simple_class_old_tag",))
 class SimpleClass(HDF5Enabled):
     """
     Simple class that implements the HDF5Enabled concept.
     """
+
     def __init__(self, x):
         self.x = int(x)
 
     def to_hdf5(self, hdf5_handle):
-        hdf5_handle['x'] = self.x
+        hdf5_handle["x"] = self.x
 
     @classmethod
     def from_hdf5(cls, hdf5_handle):
-        return cls(x=hdf5_handle['x'][()])
+        return cls(x=hdf5_handle["x"][()])
 
     def __eq__(self, other):
         return self.x == other.x
@@ -32,12 +31,13 @@ class SimpleClass(HDF5Enabled):
         return iter([self.x])
 
 
-@subscribe_hdf5('test.auto_class')
+@subscribe_hdf5("test.auto_class")
 class AutoClass(SimpleHDF5Mapping):
     """
     Class which uses the automatic serialization.
     """
-    HDF5_ATTRIBUTES = ['x', 'y']
+
+    HDF5_ATTRIBUTES = ["x", "y"]
 
     def __init__(self, x, y):
         self.x = x
@@ -47,13 +47,14 @@ class AutoClass(SimpleHDF5Mapping):
         return self.x == other.x and self.y == other.y
 
 
-@subscribe_hdf5('test.auto_class_with_optional')
+@subscribe_hdf5("test.auto_class_with_optional")
 class AutoClassWithOptional(AutoClass):
     """
     Class which uses the automatic serialization, with optional attributes.
     """
-    HDF5_ATTRIBUTES = ['x', 'y']
-    HDF5_OPTIONAL = ['z']
+
+    HDF5_ATTRIBUTES = ["x", "y"]
+    HDF5_OPTIONAL = ["z"]
 
     def __init__(self, x, y, z=None):
         super().__init__(x=x, y=y)
@@ -63,19 +64,20 @@ class AutoClassWithOptional(AutoClass):
     def __eq__(self, other):
         if not super().__eq__(other):
             return False
-        if hasattr(self, 'z') != hasattr(other, 'z'):
+        if hasattr(self, "z") != hasattr(other, "z"):
             return False
-        if hasattr(self, 'z'):
+        if hasattr(self, "z"):
             return self.z == other.z
         return True
 
 
-@subscribe_hdf5('test.auto_class_child')
+@subscribe_hdf5("test.auto_class_child")
 class AutoClassChild(AutoClass):
     """
     Class which inherits from a class using the automatic serialization feature.
     """
-    HDF5_ATTRIBUTES = AutoClass.HDF5_ATTRIBUTES + ['z']
+
+    HDF5_ATTRIBUTES = AutoClass.HDF5_ATTRIBUTES + ["z"]
 
     def __init__(self, x, y, z):
         super().__init__(x, y)
@@ -85,40 +87,44 @@ class AutoClassChild(AutoClass):
         return super().__eq__(other) and self.z == other.z
 
 
-@subscribe_hdf5('test.invalid_attribute_keys')
+@subscribe_hdf5("test.invalid_attribute_keys")
 class InvalidAttributeKeyType(SimpleHDF5Mapping):
     """
     SimpleHDF5Mapping with wrongly-typed HDF5_ATTRIBUTES.
     """
+
     HDF5_ATTRIBUTES = [1, None]
 
 
-@subscribe_hdf5('test.invalid_optional_keys')
+@subscribe_hdf5("test.invalid_optional_keys")
 class InvalidOptionalKeyType(SimpleHDF5Mapping):
     """
     SimpleHDF5Mapping with wrongly-typed HDF5_OPTIONAL.
     """
+
     HDF5_OPTIONAL = [1, None]
 
 
-@subscribe_hdf5('test.clashing_keys')
+@subscribe_hdf5("test.clashing_keys")
 class ClashingKeys(SimpleHDF5Mapping):
     """
     SimpleHDF5Mapping with clashing HDF5_ATTRIBUTES and HDF5_OPTIONAL
     """
-    HDF5_ATTRIBUTES = ['a', 'b', 'c']
-    HDF5_OPTIONAL = ['b', 'c', 'd']
+
+    HDF5_ATTRIBUTES = ["a", "b", "c"]
+    HDF5_OPTIONAL = ["b", "c", "d"]
 
 
-@subscribe_hdf5('test.legacy_class', check_on_load=False)
+@subscribe_hdf5("test.legacy_class", check_on_load=False)
 class LegacyClass(SimpleClass):
     """
     Class which accepts kwargs in 'from_hdf5', and should work without 'type_tag'.
     """
-    def __init__(self, x, y=0.):
+
+    def __init__(self, x, y=0.0):
         super().__init__(x=x)
         self.y = float(y)
 
     @classmethod
     def from_hdf5(cls, hdf5_handle, **kwargs):  # pylint: disable=arguments-differ
-        return cls(x=hdf5_handle['x'][()], **kwargs)
+        return cls(x=hdf5_handle["x"][()], **kwargs)

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -5,23 +5,29 @@ Tests for saving and loading a simple class.
 import tempfile
 
 import h5py
-import pytest
 import numpy as np
+import pytest
 from numpy.testing import assert_equal
-
-from fsc.hdf5_io import save, load
-
 from simple_class import (
-    SimpleClass, LegacyClass, AutoClass, AutoClassChild, AutoClassWithOptional,
-    InvalidAttributeKeyType, InvalidOptionalKeyType, ClashingKeys
+    AutoClass,
+    AutoClassChild,
+    AutoClassWithOptional,
+    ClashingKeys,
+    InvalidAttributeKeyType,
+    InvalidOptionalKeyType,
+    LegacyClass,
+    SimpleClass,
 )
 
+from fsc.hdf5_io import load, save
 
-@pytest.fixture(params=['tempfile', 'permanent'])
+
+@pytest.fixture(params=["tempfile", "permanent"])
 def check_save_load(request, test_name, sample_dir):
     """
     Check that a given object remains the same when saved and loaded.
     """
+
     def inner_tempfile(x):
         with tempfile.NamedTemporaryFile() as named_file:
             save(x, named_file.name)
@@ -32,15 +38,15 @@ def check_save_load(request, test_name, sample_dir):
         """
         Compares the current value against a value loaded from a sample file. The file is created if it doesn't exist, and an error is raised.
         """
-        file_name = sample_dir / (test_name + '.hdf5').replace('/', '_')
+        file_name = sample_dir / (test_name + ".hdf5").replace("/", "_")
         try:
             y = load(file_name)
             assert_equal(x, y)
-        except IOError:
+        except OSError as exc:
             save(x, file_name)
-            raise ValueError("Sample file did not exist")
+            raise ValueError("Sample file did not exist") from exc
 
-    if request.param == 'tempfile':
+    if request.param == "tempfile":
         return inner_tempfile
     return inner_permanent
 
@@ -59,7 +65,7 @@ def test_file_method():
     """
     x = SimpleClass(6)
     with tempfile.NamedTemporaryFile() as named_file:
-        with h5py.File(named_file.name, 'r+') as h5_file:
+        with h5py.File(named_file.name, "r+") as h5_file:
             x.to_hdf5(h5_file)
             y = SimpleClass.from_hdf5(h5_file)
     assert x == y
@@ -96,7 +102,7 @@ def test_str(check_save_load):  # pylint: disable=redefined-outer-name
     """
     Test string serialization.
     """
-    x = 'foobar'
+    x = "foobar"
     check_save_load(x)
 
 
@@ -104,7 +110,7 @@ def test_bytes(check_save_load):  # pylint: disable=redefined-outer-name
     """
     Test bytes serialization.
     """
-    x = b'foobar'
+    x = b"foobar"
     check_save_load(x)
 
 
@@ -121,10 +127,10 @@ def test_dict(check_save_load):  # pylint: disable=redefined-outer-name
     Test dict serialization.
     """
     x = {
-        'a': SimpleClass(4),
-        'b': [SimpleClass(1), SimpleClass(10)],
+        "a": SimpleClass(4),
+        "b": [SimpleClass(1), SimpleClass(10)],
         SimpleClass(2): 4,
-        (1, 2, 3): 5
+        (1, 2, 3): 5,
     }
     check_save_load(x)
 
@@ -140,15 +146,15 @@ def test_auto_class(check_save_load):  # pylint: disable=redefined-outer-name
     """
     Test serialization using the ``SimpleHDF5Mapping``.
     """
-    check_save_load(AutoClass(x=2., y=[1, 2., 3., SimpleClass(3)]))
+    check_save_load(AutoClass(x=2.0, y=[1, 2.0, 3.0, SimpleClass(3)]))
 
 
 @pytest.mark.parametrize(
-    'obj',
-    [AutoClassWithOptional(x=1, y=2),
-     AutoClassWithOptional(x=1, y=2, z=3)]
+    "obj", [AutoClassWithOptional(x=1, y=2), AutoClassWithOptional(x=1, y=2, z=3)]
 )
-def test_optional_attributes(check_save_load, obj):  # pylint: disable=redefined-outer-name
+def test_optional_attributes(
+    check_save_load, obj
+):  # pylint: disable=redefined-outer-name
     """
     Test the ``SimpleHDF5Mapping`` with optional attributes.
     """
@@ -159,11 +165,14 @@ def test_auto_class_child(check_save_load):  # pylint: disable=redefined-outer-n
     """
     Test serialization using the ``SimpleHDF5Mapping`` with inheritance.
     """
-    from fsc.hdf5_io._subscribe import SERIALIZE_MAPPING
+    from fsc.hdf5_io._subscribe import (  # pylint: disable=import-outside-toplevel
+        SERIALIZE_MAPPING,
+    )
+
     print(SERIALIZE_MAPPING)
     check_save_load(
         AutoClassChild(
-            x=2., y=[1, 2., 3., SimpleClass(3)], z=AutoClass(x=1., y=[3])
+            x=2.0, y=[1, 2.0, 3.0, SimpleClass(3)], z=AutoClass(x=1.0, y=[3])
         )
     )
 
@@ -172,26 +181,28 @@ def test_load_old_dict(sample_dir):
     """
     Test that the 'legacy' version of dict can be de-serialized.
     """
-    x = load(sample_dir / 'old_dict.hdf5')
-    assert x == {'a': SimpleClass(4), 'b': [SimpleClass(1), SimpleClass(10)]}
+    x = load(sample_dir / "old_dict.hdf5")
+    assert x == {"a": SimpleClass(4), "b": [SimpleClass(1), SimpleClass(10)]}
 
 
 def test_legacyclass_notag(sample_dir):
     """
     Test that the 'LegacyClass.from_hdf5_file' works even if no 'type_tag' is given.
     """
-    x = LegacyClass.from_hdf5_file(sample_dir / 'no_tag.hdf5', y=1.2)
+    x = LegacyClass.from_hdf5_file(sample_dir / "no_tag.hdf5", y=1.2)
     assert x.x == 10
     assert x.y == 1.2
 
 
 @pytest.mark.parametrize(
-    'obj', [
+    "obj",
+    [
         np.array([[1, 2, 3], [4, 5, 6]]),
-        np.array([1, 2., None, 'foo'], dtype=object),
-        np.array(['foo', 'bar', 'baz']), (np.array(['foo', 'bar', 'baz']), ),
-        np.array([[1, 2], [4, 5]], dtype=[('age', 'i4'), ('weight', 'f4')])
-    ]
+        np.array([1, 2.0, None, "foo"], dtype=object),
+        np.array(["foo", "bar", "baz"]),
+        (np.array(["foo", "bar", "baz"]),),
+        np.array([[1, 2], [4, 5]], dtype=[("age", "i4"), ("weight", "f4")]),
+    ],
 )
 def test_numpy_array(check_save_load, obj):  # pylint: disable=redefined-outer-name
     """
@@ -205,28 +216,25 @@ def test_unhashable_dict_key(sample_dir):
     Test loading an invalid dictionary with keys that can not be made
     hashable.
     """
-    filename = sample_dir / 'invalid' / 'unhashable_dict_key.hdf5'
+    filename = sample_dir / "invalid" / "unhashable_dict_key.hdf5"
     with pytest.raises(ValueError):
         load(filename)
 
 
 @pytest.mark.parametrize(
-    'filename', ['inexistent_tag.hdf5', 'inexistent_tag_with_entrypoint.hdf5']
+    "filename", ["inexistent_tag.hdf5", "inexistent_tag_with_entrypoint.hdf5"]
 )
 def test_inexistent_tag(sample_dir, filename):
     """
     Test loading files with inexistent type tags.
     """
-    filename_full = sample_dir / 'invalid' / filename
+    filename_full = sample_dir / "invalid" / filename
     with pytest.raises(KeyError):
         load(filename_full)
 
 
 @pytest.mark.parametrize(
-    'obj',
-    [InvalidAttributeKeyType(),
-     InvalidOptionalKeyType(),
-     ClashingKeys()]
+    "obj", [InvalidAttributeKeyType(), InvalidOptionalKeyType(), ClashingKeys()]
 )
 def test_incorrect_key_check(obj):
     """

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -88,7 +88,7 @@ def test_number(check_save_load):  # pylint: disable=redefined-outer-name
     """
     Test number serialization.
     """
-    x = [3, np.float(2.3), 1 + 3j]
+    x = [3, np.float64(2.3), 1 + 3j]
     check_save_load(x)
 
 

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -3,9 +3,9 @@ Test the subscribe_hdf5 decorator.
 """
 
 import pytest
-from fsc.hdf5_io import subscribe_hdf5
-
 from simple_class import SimpleClass
+
+from fsc.hdf5_io import subscribe_hdf5
 
 
 def test_duplicate_throws():
@@ -14,7 +14,7 @@ def test_duplicate_throws():
     """
     with pytest.raises(ValueError):
 
-        @subscribe_hdf5('test.simple_class')
+        @subscribe_hdf5("test.simple_class")
         class Foo:  # pylint: disable=unused-variable
             pass
 
@@ -23,5 +23,5 @@ def test_load_old_tag(sample_dir):
     """
     Test that data set with an 'extra_tag' can be deserialized.
     """
-    x = SimpleClass.from_hdf5_file(sample_dir / 'old_tag.hdf5')
+    x = SimpleClass.from_hdf5_file(sample_dir / "old_tag.hdf5")
     assert x == SimpleClass(10)

--- a/tests/test_sympy.py
+++ b/tests/test_sympy.py
@@ -5,15 +5,13 @@ is not installed.
 
 import pytest
 
-sympy = pytest.importorskip('sympy')  # pylint: disable=invalid-name
+sympy = pytest.importorskip("sympy")
 
 from test_save_load import check_save_load  # pylint: disable=unused-import
 
 
 @pytest.mark.parametrize(
-    'obj',
-    [sympy.sympify('Matrix([[1, I], [x, y]])'),
-     sympy.sympify('1 + x + z**2')]
+    "obj", [sympy.sympify("Matrix([[1, I], [x, y]])"), sympy.sympify("1 + x + z**2")]
 )
 def test_sympy(check_save_load, obj):  # pylint: disable=redefined-outer-name
     """


### PR DESCRIPTION
The newer h5py version can raise TypeError in addition to
AttributeError when trying to treat an hdf5 object as a dataset.
By catching both errors, we can be compatible with this version.